### PR TITLE
Add Android example

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,7 +1,6 @@
 # HaramBlur Extension
 
-HaramBlur is a browser extension that allows you to navigate the web with respect for your Islamic values, privacy and reduce browsing distractions.
-
+HaramBlur is a browser extension that allows you to navigate the web with respect for your Islamic values, privacy, and reduce browsing distractions.
 HaramBlur utilizes face detection and NSFW content detection and provides controls that allow you to uphold the Islamic gaze protection principle and tailor your online experience by automatically blurring images and videos that contain unwanted or impermissible content.
 
 You can configure the type of detection you want and the amount of blur, the level of strictness, hover to unblur, choose a specific gender to blur, or turn the extension on and off via the interactive pop-up 😄
@@ -88,6 +87,18 @@ npm run release
 -   Press the gear icon.
 -   Click "Install Add-on from file"
 -   Select the zip file that you generated in Step 5.
+
+## Android App Example
+
+A minimal React Native implementation is available in the `android-app` directory. It reuses the detection logic with `tfjs-react-native`.
+
+```bash
+cd android-app
+npm install
+npm run android
+```
+
+For blurring content from other apps, see the notes in `android-app/README.md`.
 
 ## Improvements
 

--- a/android-app/App.js
+++ b/android-app/App.js
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from "react";
+import { StyleSheet, View, Image, Button } from "react-native";
+import * as ImagePicker from "expo-image-picker";
+import { decodeJpeg } from "@tensorflow/tfjs-react-native";
+import { createDetector, analyze } from "./detector";
+
+export default function App() {
+    const [image, setImage] = useState(null);
+    const [blurred, setBlurred] = useState(false);
+    const [detector, setDetector] = useState(null);
+
+    useEffect(() => {
+        (async () => {
+            setDetector(await createDetector());
+        })();
+    }, []);
+
+    const pickImage = async () => {
+        const result = await ImagePicker.launchImageLibraryAsync({});
+        if (!result.canceled) {
+            setImage(result.assets[0].uri);
+            setBlurred(false);
+        }
+    };
+
+    const runDetection = async () => {
+        if (!detector || !image) return;
+        const response = await fetch(image, {}, { isBinary: true });
+        const buffer = await response.arrayBuffer();
+        const tensor = decodeJpeg(new Uint8Array(buffer));
+        const { faceRes, nsfwRes } = await analyze(detector, tensor);
+        if (faceRes.face?.length || nsfwRes.some((c) => c.probability > 0.7)) {
+            setBlurred(true);
+        }
+    };
+
+    return (
+        <View style={styles.container}>
+            {image && (
+                <Image
+                    style={[styles.image, blurred && { opacity: 0.1 }]}
+                    source={{ uri: image }}
+                />
+            )}
+            <Button title="Pick image" onPress={pickImage} />
+            <Button title="Analyze" onPress={runDetection} />
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: { flex: 1, justifyContent: "center", alignItems: "center" },
+    image: { width: 300, height: 300, marginBottom: 20 },
+});

--- a/android-app/README.md
+++ b/android-app/README.md
@@ -1,0 +1,31 @@
+# HaramBlur Android Example
+
+This directory provides a minimal React Native example that demonstrates how the blur logic can be reused on Android devices. It loads the same Human and NSFW models used by the browser extension via `tfjs-react-native`.
+
+## Prerequisites
+
+-   Node.js and Yarn or npm
+-   Android Studio or the Android SDK
+-   `expo` CLI for easier testing (`npm install -g expo-cli`)
+
+## Getting Started
+
+```bash
+cd android-app
+npm install
+npm run android
+```
+
+This will launch the React Native packager and build the app on a connected Android emulator or device.
+
+The example allows picking an image from the gallery, runs the face and NSFW detectors, and blurs the image when unwanted content is found.
+
+## Background Blur Service
+
+To blur content from other applications (e.g. YouTube or Facebook), a background service must capture the screen using the `MediaProjection` API and process each frame through the detector. A rough outline:
+
+1. Request the `MEDIA_PROJECTION` permission and start a `Service` using `MediaProjectionManager`.
+2. Capture frames from the screen and convert them to tensors.
+3. Run the detectors from `detector.js` and overlay a blur view on detected regions.
+
+Implementing a full background service is beyond the scope of this simple example, but the provided React Native code shows how detection can run on-device.

--- a/android-app/detector.js
+++ b/android-app/detector.js
@@ -1,0 +1,24 @@
+import "@tensorflow/tfjs-react-native";
+import * as tf from "@tensorflow/tfjs-core";
+import Human from "@vladmandic/human";
+import * as nsfwjs from "nsfwjs";
+
+const humanConfig = {
+    modelBasePath: "https://cdn.jsdelivr.net/npm/@vladmandic/human/models/",
+    face: { enabled: true },
+    filter: { enabled: false },
+};
+
+export async function createDetector() {
+    await tf.ready();
+    const human = new Human(humanConfig);
+    await human.load();
+    const nsfwModel = await nsfwjs.load();
+    return { human, nsfwModel };
+}
+
+export async function analyze(detector, imageTensor) {
+    const faceRes = await detector.human.detect(imageTensor, "detect");
+    const nsfwRes = await detector.nsfwModel.classify(imageTensor);
+    return { faceRes, nsfwRes };
+}

--- a/android-app/package.json
+++ b/android-app/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "haramblur-android",
+    "private": true,
+    "scripts": {
+        "start": "react-native start",
+        "android": "react-native run-android"
+    },
+    "dependencies": {
+        "@tensorflow/tfjs-react-native": "^0.9.0",
+        "@vladmandic/human": "^2.0.1",
+        "react": "18.2.0",
+        "react-native": "0.72.4"
+    }
+}


### PR DESCRIPTION
## Summary
- fix README typo and add section for Android example
- add basic React Native example under `android-app`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c6839a680832ebd2cfe387267ca96